### PR TITLE
Form266 (signing, locking pdf via pdflatex)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+BUILD=bin
+
+.PHONY: all
+
+all: clean
+	mkdir -p $(BUILD)
+	pdftex arl-form-266.tex --output-directory $(BUILD)
+
+clean:
+	mkdir -p $(BUILD)
+	rm -f $(BUILD)/*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD=bin
 
 all: clean
 	mkdir -p $(BUILD)
-	pdftex arl-form-266.tex --output-directory $(BUILD)
+	pdflatex -output-directory=$(BUILD) arl-form-266.tex
 
 clean:
 	mkdir -p $(BUILD)

--- a/arl-form-266.tex
+++ b/arl-form-266.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{hyperref}
+\usepackage{eforms}
+\begin{document}
+\begin{Form}
+    \TextField{Name} \\\        \CheckBox[width=1em]{Check}\\\ 
+    \sigField[\Lock{/Action/All}]{signature}{5cm}{3cm}
+\end{Form}
+\end{document}


### PR DESCRIPTION
As it relates to #1, I've included a simple Makefile and a simple "arl-form-266.tex" that should be completely altered to contain the tex of the actual form BUT the important thing is:

1. This does produce a signable document
2. Signing the document will lock the fields

If someone can dump a tex version of ARL from 266 into arl-form-266.tex, I can play with it from there (blow away the fields/signature I have in there, I just want a placeholder that I can look at in history).

On Arch Linux this build requires:
conv-xkv - manually installed (for now)
acrotex (for eforms) - in the AUR

please refer to #1 for prior links references but additionally:
http://tex.stackexchange.com/questions/88754/locking-fields-in-digital-signature